### PR TITLE
fix: Resolve SQLite corruption from working directory mismatch

### DIFF
--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,8 +1,111 @@
 import Database from 'better-sqlite3';
+import { existsSync, unlinkSync } from 'fs';
 
-export function initDB(path: string = 'rpg.db'): Database.Database {
-    const db = new Database(path);
+export interface DatabaseIntegrityResult {
+    ok: boolean;
+    errors: string[];
+}
+
+/**
+ * Check database integrity using SQLite's integrity_check pragma.
+ */
+export function checkDatabaseIntegrity(db: Database.Database): DatabaseIntegrityResult {
+    try {
+        const result = db.pragma('integrity_check') as { integrity_check: string }[];
+        const errors = result
+            .map(row => row.integrity_check)
+            .filter(msg => msg !== 'ok');
+
+        return {
+            ok: errors.length === 0,
+            errors
+        };
+    } catch (e) {
+        return {
+            ok: false,
+            errors: [(e as Error).message]
+        };
+    }
+}
+
+/**
+ * Attempt to recover a corrupted database by creating a fresh one.
+ * Returns true if recovery was needed and performed.
+ */
+function handleCorruptedDatabase(path: string, error: Error): void {
+    console.error(`[Database] CRITICAL: Database corruption detected at ${path}`);
+    console.error(`[Database] Error: ${error.message}`);
+
+    // Check for WAL files
+    const walPath = `${path}-wal`;
+    const shmPath = `${path}-shm`;
+
+    console.error('[Database] Attempting recovery by removing corrupted files...');
+
+    try {
+        if (existsSync(path)) {
+            unlinkSync(path);
+            console.error(`[Database] Removed corrupted database: ${path}`);
+        }
+        if (existsSync(walPath)) {
+            unlinkSync(walPath);
+            console.error(`[Database] Removed WAL file: ${walPath}`);
+        }
+        if (existsSync(shmPath)) {
+            unlinkSync(shmPath);
+            console.error(`[Database] Removed SHM file: ${shmPath}`);
+        }
+        console.error('[Database] Recovery complete. A fresh database will be created.');
+    } catch (cleanupError) {
+        console.error(`[Database] Failed to clean up corrupted files: ${(cleanupError as Error).message}`);
+        throw new Error(`Database is corrupted and cleanup failed. Please manually delete: ${path}, ${walPath}, ${shmPath}`);
+    }
+}
+
+export function initDB(path: string): Database.Database {
+    console.error(`[Database] Opening database: ${path}`);
+
+    let db: Database.Database;
+
+    try {
+        db = new Database(path);
+    } catch (e) {
+        const error = e as Error;
+        // If we can't even open the database, it's likely corrupted
+        if (error.message.includes('SQLITE_CORRUPT') || error.message.includes('malformed')) {
+            handleCorruptedDatabase(path, error);
+            // Try again with fresh database
+            db = new Database(path);
+        } else {
+            throw e;
+        }
+    }
+
+    // Set pragmas
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');
+
+    // Run integrity check on existing databases
+    const integrity = checkDatabaseIntegrity(db);
+    if (!integrity.ok) {
+        console.error('[Database] Integrity check failed:');
+        integrity.errors.forEach(err => console.error(`  - ${err}`));
+
+        // Close the corrupted database
+        db.close();
+
+        // Handle the corruption
+        handleCorruptedDatabase(path, new Error(integrity.errors.join(', ')));
+
+        // Create fresh database
+        db = new Database(path);
+        db.pragma('journal_mode = WAL');
+        db.pragma('foreign_keys = ON');
+
+        console.error('[Database] Fresh database created after corruption recovery');
+    } else {
+        console.error('[Database] Integrity check passed');
+    }
+
     return db;
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,12 +1,86 @@
 import Database from 'better-sqlite3';
+import { join, dirname, isAbsolute } from 'path';
 import { initDB } from './db.js';
 import { migrate } from './migrations.js';
 
 let dbInstance: Database.Database | null = null;
+let configuredDbPath: string | null = null;
 
-export function getDb(path: string = 'rpg.db'): Database.Database {
+/**
+ * Get the default database path.
+ * Uses environment variable, CLI argument, or falls back to user data directory.
+ */
+function getDefaultDbPath(): string {
+    // Check for environment variable first
+    if (process.env.RPG_MCP_DB_PATH) {
+        return process.env.RPG_MCP_DB_PATH;
+    }
+
+    // Check for CLI argument --db-path
+    const args = process.argv;
+    const dbPathIndex = args.indexOf('--db-path');
+    if (dbPathIndex !== -1 && args[dbPathIndex + 1]) {
+        return args[dbPathIndex + 1];
+    }
+
+    // Fall back to executable directory or current working directory
+    // For bundled executables, use the directory containing the executable
+    const exePath = process.execPath;
+    const exeDir = dirname(exePath);
+
+    // Check if we're running as a bundled executable (pkg/esbuild bundle)
+    // The bundled executable will have a snapshot filesystem
+    // Use type assertion since 'pkg' is added by the pkg bundler at runtime
+    if ((process as unknown as { pkg?: unknown }).pkg || exePath.includes('rpg-mcp-server')) {
+        return join(exeDir, 'rpg.db');
+    }
+
+    // For development, use current working directory
+    return join(process.cwd(), 'rpg.db');
+}
+
+/**
+ * Resolve database path, ensuring it's absolute.
+ */
+function resolveDbPath(path?: string): string {
+    const dbPath = path || configuredDbPath || getDefaultDbPath();
+
+    // Special case: SQLite in-memory database
+    if (dbPath === ':memory:') {
+        return dbPath;
+    }
+
+    if (isAbsolute(dbPath)) {
+        return dbPath;
+    }
+
+    // Make relative paths absolute based on CWD
+    return join(process.cwd(), dbPath);
+}
+
+/**
+ * Configure the database path before initialization.
+ * Call this before getDb() to set a custom path.
+ */
+export function configureDbPath(path: string): void {
+    if (dbInstance) {
+        throw new Error('Cannot configure database path after database has been initialized');
+    }
+    configuredDbPath = isAbsolute(path) ? path : join(process.cwd(), path);
+}
+
+/**
+ * Get the configured or default database path (for logging/debugging).
+ */
+export function getDbPath(): string {
+    return resolveDbPath();
+}
+
+export function getDb(path?: string): Database.Database {
     if (!dbInstance) {
-        dbInstance = initDB(path);
+        const resolvedPath = resolveDbPath(path);
+        console.error(`[Database] Initializing database at: ${resolvedPath}`);
+        dbInstance = initDB(resolvedPath);
         migrate(dbInstance);
     }
     return dbInstance;
@@ -16,10 +90,22 @@ export function setDb(database: Database.Database) {
     dbInstance = database;
 }
 
+/**
+ * Close the database with proper WAL checkpoint.
+ * This ensures all WAL data is written to the main database file.
+ */
 export function closeDb() {
     if (dbInstance) {
+        try {
+            // Checkpoint WAL to ensure all changes are written to main database
+            dbInstance.pragma('wal_checkpoint(TRUNCATE)');
+            console.error('[Database] WAL checkpoint completed');
+        } catch (e) {
+            console.error('[Database] WAL checkpoint failed:', (e as Error).message);
+        }
         dbInstance.close();
         dbInstance = null;
+        console.error('[Database] Database closed');
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes critical SQLite database corruption caused by working directory mismatch when running as a Tauri sidecar.

**Root Cause:** The sidecar binary was creating an orphaned `rpg.db` in `src-tauri/binaries/` while the main database with WAL files existed in `src-tauri/`, causing a split-brain condition and `SQLITE_CORRUPT` errors.

### Changes

- **Absolute path resolution**: Database path is now always resolved to an absolute path, preventing orphaned databases
- **CLI/env configuration**: Support `--db-path` argument and `RPG_MCP_DB_PATH` environment variable
- **Integrity checking**: Run SQLite `integrity_check` on startup with automatic recovery for corrupted databases
- **WAL checkpoint on shutdown**: Properly checkpoint and close database on SIGINT/SIGTERM/SIGBREAK
- **Graceful shutdown handlers**: Handle all termination signals and uncaught exceptions

### Usage

```bash
# Via CLI argument
rpg-mcp-server --db-path /path/to/data/rpg.db

# Via environment variable  
RPG_MCP_DB_PATH=/path/to/data/rpg.db rpg-mcp-server
```

## Test plan

- [x] Build passes
- [x] Existing tests pass (31 pre-existing failures unrelated to these changes)
- [ ] Verify sidecar uses correct database path when launched from Tauri
- [ ] Verify corruption recovery works by corrupting a test database

🤖 Generated with [Claude Code](https://claude.com/claude-code)