### PR TITLE
fix(combat): accept compound dice notation like "1d6+4+2d6"

### DIFF
--- a/src/engine/combat/rng.ts
+++ b/src/engine/combat/rng.ts
@@ -26,25 +26,22 @@ export class CombatRNG {
     }
 
     /**
-     * Parse and execute standard dice notation (NdS+M or NdS-M)
-     * Examples: "1d20", "2d6+3", "1d8-1"
+     * Parse and execute standard dice notation, including multi-term sums.
+     * Examples: "1d20", "2d6+3", "1d8-1", "1d6+4+2d6" (sneak attack), "1d8+3+2d8" (smite)
      */
     roll(notation: string): number {
-        const match = notation.match(/^(\d+)d(\d+)(([+\-])(\d+))?$/i);
-        if (!match) {
-            throw new Error(`Invalid dice notation: ${notation}`);
-        }
-
-        const count = parseInt(match[1], 10);
-        const sides = parseInt(match[2], 10);
-        const modifier = match[3] ? parseInt(match[4] + match[5], 10) : 0;
-
+        const terms = parseDiceTerms(notation);
         let total = 0;
-        for (let i = 0; i < count; i++) {
-            total += this.rollDie(sides);
+        for (const term of terms) {
+            if (term.kind === 'dice') {
+                for (let i = 0; i < term.count; i++) {
+                    total += term.sign * this.rollDie(term.sides);
+                }
+            } else {
+                total += term.sign * term.value;
+            }
         }
-
-        return total + modifier;
+        return total;
     }
 
     /**
@@ -276,34 +273,33 @@ export class CombatRNG {
     }
 
     /**
-     * Roll damage dice with detailed breakdown
+     * Roll damage dice with detailed breakdown.
+     * Supports compound expressions like "1d6+4+2d6" (sneak attack) and "1d8+3+2d8" (smite).
      */
     rollDamageDetailed(notation: string): DamageResult {
-        const match = notation.match(/^(\d+)d(\d+)(([+\-])(\d+))?$/i);
-        if (!match) {
-            throw new Error(`Invalid dice notation: ${notation}`);
-        }
-
-        const count = parseInt(match[1], 10);
-        const sides = parseInt(match[2], 10);
-        const modifierSign = match[4] || '+';
-        const modifierValue = match[5] ? parseInt(match[5], 10) : 0;
-        const modifier = modifierSign === '-' ? -modifierValue : modifierValue;
-
+        const terms = parseDiceTerms(notation);
         const rolls: number[] = [];
-        for (let i = 0; i < count; i++) {
-            rolls.push(this.rollDie(sides));
-        }
+        let diceTotal = 0;
+        let modifier = 0;
 
-        const diceTotal = rolls.reduce((sum, r) => sum + r, 0);
-        const total = diceTotal + modifier;
+        for (const term of terms) {
+            if (term.kind === 'dice') {
+                for (let i = 0; i < term.count; i++) {
+                    const r = this.rollDie(term.sides);
+                    rolls.push(term.sign * r);
+                    diceTotal += term.sign * r;
+                }
+            } else {
+                modifier += term.sign * term.value;
+            }
+        }
 
         return {
             notation,
             rolls,
             diceTotal,
             modifier,
-            total
+            total: diceTotal + modifier
         };
     }
 }
@@ -333,4 +329,50 @@ export interface DamageResult {
     diceTotal: number;      // Sum of dice only
     modifier: number;       // Flat modifier
     total: number;          // Final damage total
+}
+
+type DiceTerm =
+    | { kind: 'dice'; count: number; sides: number; sign: 1 | -1 }
+    | { kind: 'scalar'; value: number; sign: 1 | -1 };
+
+/**
+ * Parse compound dice notation into a list of terms.
+ * Accepts a `+`/`-`-joined chain of dice (`NdS`, `dS`) and integers.
+ * Examples: `1d6+4+2d6`, `1d8+3+2d8`, `2d6+1d4-2`, `d20+5`.
+ */
+export function parseDiceTerms(notation: string): DiceTerm[] {
+    const stripped = notation.replace(/\s+/g, '');
+    if (!stripped) {
+        throw new Error(`Invalid dice notation: ${notation}`);
+    }
+    // Split on +/- while preserving the sign with each term.
+    const tokens = stripped.match(/[+-]?[^+-]+/g);
+    if (!tokens) {
+        throw new Error(`Invalid dice notation: ${notation}`);
+    }
+
+    const terms: DiceTerm[] = [];
+    for (const raw of tokens) {
+        const sign: 1 | -1 = raw.startsWith('-') ? -1 : 1;
+        const body = raw.replace(/^[+-]/, '');
+        if (!body) {
+            throw new Error(`Invalid dice notation: ${notation}`);
+        }
+        const diceMatch = body.match(/^(\d*)d(\d+)$/i);
+        if (diceMatch) {
+            const count = diceMatch[1] === '' ? 1 : parseInt(diceMatch[1], 10);
+            const sides = parseInt(diceMatch[2], 10);
+            if (count <= 0 || sides <= 0) {
+                throw new Error(`Invalid dice notation: ${notation}`);
+            }
+            terms.push({ kind: 'dice', count, sides, sign });
+            continue;
+        }
+        if (/^\d+$/.test(body)) {
+            terms.push({ kind: 'scalar', value: parseInt(body, 10), sign });
+            continue;
+        }
+        throw new Error(`Invalid dice notation: ${notation}`);
+    }
+    return terms;
 }

--- a/src/engine/combat/rng.ts
+++ b/src/engine/combat/rng.ts
@@ -339,25 +339,31 @@ type DiceTerm =
  * Parse compound dice notation into a list of terms.
  * Accepts a `+`/`-`-joined chain of dice (`NdS`, `dS`) and integers.
  * Examples: `1d6+4+2d6`, `1d8+3+2d8`, `2d6+1d4-2`, `d20+5`.
+ *
+ * Strict grammar — rejects malformed operator chains like `1d6++2`,
+ * `1d6--2`, `1d6+`, or trailing operators. Pattern:
+ *   <term> ( [+-] <term> )*
+ *   <term> := <int> | <int>?d<int>
+ * with at most one leading sign.
  */
 export function parseDiceTerms(notation: string): DiceTerm[] {
     const stripped = notation.replace(/\s+/g, '');
     if (!stripped) {
         throw new Error(`Invalid dice notation: ${notation}`);
     }
-    // Split on +/- while preserving the sign with each term.
-    const tokens = stripped.match(/[+-]?[^+-]+/g);
-    if (!tokens) {
+    const TERM = String.raw`(?:\d*d\d+|\d+)`;
+    const STRICT = new RegExp(`^[+-]?${TERM}(?:[+-]${TERM})*$`, 'i');
+    if (!STRICT.test(stripped)) {
         throw new Error(`Invalid dice notation: ${notation}`);
     }
+
+    // Tokenize once the grammar check has passed.
+    const tokens = stripped.match(/[+-]?[^+-]+/g)!;
 
     const terms: DiceTerm[] = [];
     for (const raw of tokens) {
         const sign: 1 | -1 = raw.startsWith('-') ? -1 : 1;
         const body = raw.replace(/^[+-]/, '');
-        if (!body) {
-            throw new Error(`Invalid dice notation: ${notation}`);
-        }
         const diceMatch = body.match(/^(\d*)d(\d+)$/i);
         if (diceMatch) {
             const count = diceMatch[1] === '' ? 1 : parseInt(diceMatch[1], 10);
@@ -368,11 +374,8 @@ export function parseDiceTerms(notation: string): DiceTerm[] {
             terms.push({ kind: 'dice', count, sides, sign });
             continue;
         }
-        if (/^\d+$/.test(body)) {
-            terms.push({ kind: 'scalar', value: parseInt(body, 10), sign });
-            continue;
-        }
-        throw new Error(`Invalid dice notation: ${notation}`);
+        // Grammar already guaranteed scalar shape.
+        terms.push({ kind: 'scalar', value: parseInt(body, 10), sign });
     }
     return terms;
 }

--- a/tests/combat/rng.test.ts
+++ b/tests/combat/rng.test.ts
@@ -54,6 +54,47 @@ describe('CombatRNG', () => {
             expect(() => rng.roll('invalid')).toThrow('Invalid dice notation');
             expect(() => rng.roll('2x6')).toThrow('Invalid dice notation');
         });
+
+        it('should parse compound sneak-attack expression (1d6+4+2d6)', () => {
+            const rng = new CombatRNG('compound-sa');
+            const result = rng.roll('1d6+4+2d6');
+            // min: 1 + 4 + 2 = 7; max: 6 + 4 + 12 = 22
+            expect(result).toBeGreaterThanOrEqual(7);
+            expect(result).toBeLessThanOrEqual(22);
+        });
+
+        it('should parse compound smite expression (1d8+3+2d8)', () => {
+            const rng = new CombatRNG('compound-smite');
+            const result = rng.roll('1d8+3+2d8');
+            // min: 1 + 3 + 2 = 6; max: 8 + 3 + 16 = 27
+            expect(result).toBeGreaterThanOrEqual(6);
+            expect(result).toBeLessThanOrEqual(27);
+        });
+
+        it('should parse mixed dice with subtraction (2d6+1d4-2)', () => {
+            const rng = new CombatRNG('compound-mixed');
+            const result = rng.roll('2d6+1d4-2');
+            // min: 2 + 1 - 2 = 1; max: 12 + 4 - 2 = 14
+            expect(result).toBeGreaterThanOrEqual(1);
+            expect(result).toBeLessThanOrEqual(14);
+        });
+
+        it('should parse shorthand single die (d20)', () => {
+            const rng = new CombatRNG('shorthand-d20');
+            const result = rng.roll('d20');
+            expect(result).toBeGreaterThanOrEqual(1);
+            expect(result).toBeLessThanOrEqual(20);
+        });
+
+        it('rollDamageDetailed returns separate dice and modifier for compound notation', () => {
+            const rng = new CombatRNG('compound-detail');
+            const detail = rng.rollDamageDetailed('1d6+4+2d6');
+            expect(detail.notation).toBe('1d6+4+2d6');
+            // 1 + 2 = 3 dice rolled; modifier = 4
+            expect(detail.rolls).toHaveLength(3);
+            expect(detail.modifier).toBe(4);
+            expect(detail.total).toBe(detail.diceTotal + detail.modifier);
+        });
     });
 
     describe('Advantage/Disadvantage', () => {

--- a/tests/combat/rng.test.ts
+++ b/tests/combat/rng.test.ts
@@ -95,6 +95,24 @@ describe('CombatRNG', () => {
             expect(detail.modifier).toBe(4);
             expect(detail.total).toBe(detail.diceTotal + detail.modifier);
         });
+
+        // Strict-grammar regression: malformed operator sequences must throw
+        // rather than silently evaluate (caught by reviewers on PR #51).
+        it.each([
+            '1d6++2',
+            '1d6--2',
+            '1d6+-2',
+            '1d6-+2',
+            '1d6+',
+            '1d6-',
+            '+',
+            '++1d6',
+            '1d6+2+',
+            '1d6 + + 2'
+        ])('rejects malformed operator sequence: %s', (notation) => {
+            const rng = new CombatRNG('malformed-ops');
+            expect(() => rng.roll(notation)).toThrow('Invalid dice notation');
+        });
     });
 
     describe('Advantage/Disadvantage', () => {


### PR DESCRIPTION
## Summary
- `CombatRNG.roll` and `rollDamageDetailed` previously matched a single-term regex, rejecting standard compound expressions (sneak attack `1d6+4+2d6`, divine smite `1d8+3+2d8`).
- Added a shared `parseDiceTerms` helper that splits on `+`/`-` preserving signs and evaluates each term as either dice or a scalar.
- Supports shorthand `dN` and mixed dice/subtraction (`2d6+1d4-2`).

## Test plan
- [x] 5 new RNG tests (sneak attack, smite, mixed +/-, shorthand, detailed-roll structure)
- [x] Full suite: 1894 passed, 6 skipped, 0 failed
- [x] `tsc --noEmit` clean

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dice notation now supports chained expressions with multiple dice terms and modifiers (e.g., 1d6+4+2d6, 2d6+1d4-2, d20+5).
  * Damage reporting now returns detailed breakdowns: per-die rolls, subtotal of dice, summed modifiers, and final total.

* **Bug Fixes**
  * Invalid or malformed operator sequences in dice notation are now rejected with an error.

* **Tests**
  * Expanded test coverage for compound notation, shorthand dice, and regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->