### PR TITLE
docs(quest): surface objective type enum and update_objective characterId requirement

### DIFF
--- a/src/server/consolidated/quest-manage.ts
+++ b/src/server/consolidated/quest-manage.ts
@@ -480,7 +480,7 @@ const definitions: Record<QuestManageAction, ActionDefinition> = {
         schema: UpdateObjectiveSchema,
         handler: handleUpdateObjective,
         aliases: ['progress', 'advance'],
-        description: 'Update objective progress'
+        description: 'Update objective progress (requires characterId — quest must be active for that character)'
     },
     complete_objective: {
         schema: CompleteObjectiveSchema,
@@ -521,10 +521,19 @@ Aliases: new→create, accept→assign, progress→update_objective, finish→co
 📜 QUEST WORKFLOW:
 1. create - Define a quest with objectives and rewards
 2. assign - Character accepts the quest
-3. update_objective - Track progress on objectives
+3. update_objective - Track progress on objectives (requires characterId)
 4. complete_objective - Mark objectives done
 5. complete - Turn in quest for rewards
-6. get_log - View character's quest journal`,
+6. get_log - View character's quest journal
+
+🎯 OBJECTIVE TYPES (for create):
+Each objective requires a "type" field. Valid values:
+- kill: defeat enemies
+- collect: gather items
+- deliver: bring an item to a destination
+- explore: visit a location
+- interact: talk to / interact with an entity
+- custom: anything else (escape, escort, survive, etc.)`,
     inputSchema: z.object({
         action: z.string().describe(`Action: ${ACTIONS.join(', ')}`),
         questId: z.string().optional().describe('Quest ID'),
@@ -534,7 +543,7 @@ Aliases: new→create, accept→assign, progress→update_objective, finish→co
         description: z.string().optional().describe('Quest description'),
         worldId: z.string().optional().describe('World ID'),
         giver: z.string().optional().describe('Quest giver name'),
-        objectives: z.array(z.any()).optional().describe('Quest objectives'),
+        objectives: z.array(z.any()).optional().describe('Quest objectives. Each requires { description, type } where type is one of: kill, collect, deliver, explore, interact, custom'),
         rewards: z.any().optional().describe('Quest rewards'),
         prerequisites: z.array(z.string()).optional(),
         status: z.string().optional(),

--- a/tests/server/consolidated/quest-manage.test.ts
+++ b/tests/server/consolidated/quest-manage.test.ts
@@ -102,6 +102,16 @@ describe('quest_manage consolidated tool', () => {
             expect(QuestManageTool.description).toContain('complete');
             expect(QuestManageTool.description).toContain('get_log');
         });
+
+        it('should document objective type enum values in description', () => {
+            for (const type of ['kill', 'collect', 'deliver', 'explore', 'interact', 'custom']) {
+                expect(QuestManageTool.description).toContain(type);
+            }
+        });
+
+        it('should document characterId requirement on update_objective', () => {
+            expect(QuestManageTool.description).toMatch(/update_objective.*characterId/i);
+        });
     });
 
     describe('create action', () => {


### PR DESCRIPTION
## Summary
Two contract-discoverability fixes for `quest_manage`:
- The objective `type` enum (`kill | collect | deliver | explore | interact | custom`) was only discoverable through validation errors. Now listed in the tool description and on the `objectives` input field.
- `update_objective` requires `characterId` (semantic requirement — quest must be active for that character), now noted in both the action description and the workflow section.

## Test plan
- [x] 2 new contract tests assert the description surfaces the enum and the characterId requirement
- [x] quest-manage suite: 27/27 pass
- [x] No code-path changes (description only)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified requirements for updating quest objectives, including the necessity of a character ID.
  * Added documentation of available objective types for quest creation (kill, collect, deliver, explore, interact, custom).

* **Tests**
  * Added verification tests to ensure quest management documentation maintains accuracy regarding objective types and character ID requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->