### PR TITLE
fix(magic): normalize spell-database keys so kebab-case lookups resolve

### DIFF
--- a/src/engine/magic/spell-database.ts
+++ b/src/engine/magic/spell-database.ts
@@ -11,13 +11,23 @@ export const SPELL_DATABASE: Map<string, Spell> = new Map();
 // Input type for spell registration (ritual defaults to false)
 type SpellInput = Omit<Spell, 'ritual'> & { ritual?: boolean };
 
-// Helper to add spell to database
+/**
+ * Normalize a spell name/id for lookup.
+ * Accepts "Fire Bolt", "fire-bolt", "fire_bolt", "FIREBOLT" — all collapse to "firebolt".
+ */
+function normalizeSpellKey(name: string): string {
+    return name.toLowerCase().replace(/[\s\-_]+/g, '');
+}
+
+// Helper to add spell to database — registers under both the spaced name
+// and the kebab-case id so all reasonable callers can find the spell.
 function registerSpell(input: SpellInput): void {
     const spell: Spell = {
         ...input,
         ritual: input.ritual ?? false
     };
-    SPELL_DATABASE.set(spell.name.toLowerCase(), spell);
+    SPELL_DATABASE.set(normalizeSpellKey(spell.name), spell);
+    SPELL_DATABASE.set(normalizeSpellKey(spell.id), spell);
 }
 
 // ============================================================================
@@ -571,17 +581,17 @@ registerSpell({
 // ============================================================================
 
 /**
- * Get spell by name (case-insensitive)
+ * Get spell by name or id (case-insensitive, ignores spaces/hyphens/underscores)
  */
 export function getSpell(name: string): Spell | undefined {
-    return SPELL_DATABASE.get(name.toLowerCase());
+    return SPELL_DATABASE.get(normalizeSpellKey(name));
 }
 
 /**
  * Check if spell exists in database
  */
 export function spellExists(name: string): boolean {
-    return SPELL_DATABASE.has(name.toLowerCase());
+    return SPELL_DATABASE.has(normalizeSpellKey(name));
 }
 
 /**
@@ -665,5 +675,6 @@ export function calculateUpcastDice(spell: Spell, slotLevel: number): string {
     return `${totalCount}d${diceSize}${modifier}`;
 }
 
-// Export total spell count for tests
-export const SPELL_COUNT = SPELL_DATABASE.size;
+// Export total unique-spell count for tests (each spell may be indexed under
+// multiple keys, so dedupe before counting).
+export const SPELL_COUNT = new Set(SPELL_DATABASE.values()).size;

--- a/src/engine/magic/spell-database.ts
+++ b/src/engine/magic/spell-database.ts
@@ -239,9 +239,78 @@ registerSpell({
     autoHit: false
 });
 
+registerSpell({
+    id: 'healing-word',
+    name: 'Healing Word',
+    level: 1,
+    school: 'evocation',
+    castingTime: 'bonus_action',
+    range: 60,
+    components: { verbal: true, somatic: false, material: false },
+    duration: 'Instantaneous',
+    concentration: false,
+    description: 'A creature of your choice within range regains 1d4 + your spellcasting ability modifier.',
+    higherLevels: 'Healing increases by 1d4 for each slot level above 1st.',
+    classes: ['bard', 'cleric', 'druid'],
+    targetType: 'creature',
+    effects: [{
+        type: 'healing',
+        dice: '1d4',
+        upcastBonus: { dice: '1d4', perLevel: 1 }
+    }],
+    autoHit: false
+});
+
 // ============================================================================
 // 2ND LEVEL SPELLS
 // ============================================================================
+
+registerSpell({
+    id: 'scorching-ray',
+    name: 'Scorching Ray',
+    level: 2,
+    school: 'evocation',
+    castingTime: 'action',
+    range: 120,
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    concentration: false,
+    description: 'You create three rays of fire and hurl them at targets within range. Each ray deals 2d6 fire on a hit.',
+    higherLevels: 'You create one additional ray for each slot level above 2nd.',
+    classes: ['sorcerer', 'wizard'],
+    targetType: 'creature',
+    effects: [{
+        type: 'damage',
+        dice: '6d6',
+        damageType: 'fire',
+        saveType: 'none',
+        upcastBonus: { dice: '2d6', perLevel: 1 }
+    }],
+    autoHit: false
+});
+
+registerSpell({
+    id: 'web',
+    name: 'Web',
+    level: 2,
+    school: 'conjuration',
+    castingTime: 'action',
+    range: 60,
+    components: { verbal: true, somatic: true, material: true, materialDescription: 'a bit of spiderweb' },
+    duration: 'Concentration, up to 1 hour',
+    concentration: true,
+    description: 'You conjure a mass of thick, sticky webbing in a 20-foot cube. Creatures starting their turn in the webs or entering them on their turn must make a Dexterity saving throw or become restrained.',
+    classes: ['sorcerer', 'wizard'],
+    targetType: 'area',
+    areaOfEffect: { shape: 'cube', size: 20 },
+    effects: [{
+        type: 'debuff',
+        saveType: 'dexterity',
+        saveEffect: 'none',
+        conditions: ['RESTRAINED']
+    }],
+    autoHit: false
+});
 
 registerSpell({
     id: 'hold-person',

--- a/src/engine/magic/spell-database.ts
+++ b/src/engine/magic/spell-database.ts
@@ -595,17 +595,26 @@ export function spellExists(name: string): boolean {
 }
 
 /**
+ * Iterate the deduplicated spell set. Each spell may live under multiple
+ * keys (name + id), so iterating SPELL_DATABASE.values() directly would
+ * yield duplicates.
+ */
+function uniqueSpells(): Spell[] {
+    return Array.from(new Set(SPELL_DATABASE.values()));
+}
+
+/**
  * Get all spells of a specific level
  */
 export function getSpellsByLevel(level: number): Spell[] {
-    return Array.from(SPELL_DATABASE.values()).filter(s => s.level === level);
+    return uniqueSpells().filter(s => s.level === level);
 }
 
 /**
  * Get all spells available to a class
  */
 export function getSpellsForClass(characterClass: SpellcastingClass): Spell[] {
-    return Array.from(SPELL_DATABASE.values()).filter(s =>
+    return uniqueSpells().filter(s =>
         s.classes.includes(characterClass)
     );
 }

--- a/tests/engine/magic/spell-database.test.ts
+++ b/tests/engine/magic/spell-database.test.ts
@@ -23,7 +23,11 @@ describe('spell-database key normalization', () => {
         ['Cure Wounds', ['cure-wounds', 'cure wounds']],
         ['Hold Person', ['hold-person', 'hold person']],
         ['Spiritual Weapon', ['spiritual-weapon', 'spiritual weapon']],
-        ['Bless', ['bless', 'BLESS']]
+        ['Bless', ['bless', 'BLESS']],
+        // Issue #41 acceptance — must resolve via either canonical name or kebab id.
+        ['Scorching Ray', ['scorching-ray', 'scorching ray']],
+        ['Healing Word', ['healing-word', 'healing word']],
+        ['Web', ['web', 'WEB']]
     ];
 
     for (const [canonical, variants] of synonyms) {

--- a/tests/engine/magic/spell-database.test.ts
+++ b/tests/engine/magic/spell-database.test.ts
@@ -8,6 +8,8 @@
 import {
     getSpell,
     spellExists,
+    getSpellsByLevel,
+    getSpellsForClass,
     SPELL_DATABASE,
     SPELL_COUNT
 } from '../../../src/engine/magic/spell-database';
@@ -43,5 +45,25 @@ describe('spell-database key normalization', () => {
     it('SPELL_COUNT counts unique spells, not key aliases', () => {
         const uniqueSpells = new Set(SPELL_DATABASE.values()).size;
         expect(SPELL_COUNT).toBe(uniqueSpells);
+    });
+});
+
+describe('spell-database iteration helpers (no duplicates)', () => {
+    // After dual-key registration, iterating SPELL_DATABASE.values() directly
+    // would yield each spell twice. The helpers must dedupe.
+    it('getSpellsByLevel returns unique spells per level', () => {
+        for (const level of [0, 1, 2, 3]) {
+            const list = getSpellsByLevel(level);
+            const ids = list.map((s) => s.id);
+            expect(new Set(ids).size).toBe(ids.length);
+        }
+    });
+
+    it('getSpellsForClass returns unique spells per class', () => {
+        for (const klass of ['wizard', 'cleric', 'sorcerer', 'warlock'] as const) {
+            const list = getSpellsForClass(klass);
+            const ids = list.map((s) => s.id);
+            expect(new Set(ids).size, `${klass} contained duplicates`).toBe(ids.length);
+        }
     });
 });

--- a/tests/engine/magic/spell-database.test.ts
+++ b/tests/engine/magic/spell-database.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Spell-database lookup regression tests.
+ * Issue #41: spells were registered under "name.toLowerCase()" (e.g. "fire bolt")
+ * but callers passed kebab-case ids (e.g. "fire-bolt"), so getSpell returned undefined
+ * for nearly every common spell despite them existing in the database.
+ */
+
+import {
+    getSpell,
+    spellExists,
+    SPELL_DATABASE,
+    SPELL_COUNT
+} from '../../../src/engine/magic/spell-database';
+
+describe('spell-database key normalization', () => {
+    const synonyms: Array<[string, string[]]> = [
+        ['Fire Bolt', ['fire-bolt', 'fire bolt', 'firebolt', 'FIRE-BOLT', 'Fire_Bolt']],
+        ['Magic Missile', ['magic-missile', 'magic missile', 'magicmissile']],
+        ['Sacred Flame', ['sacred-flame', 'sacred flame', 'SACREDFLAME']],
+        ['Eldritch Blast', ['eldritch-blast', 'eldritch blast']],
+        ['Cure Wounds', ['cure-wounds', 'cure wounds']],
+        ['Hold Person', ['hold-person', 'hold person']],
+        ['Spiritual Weapon', ['spiritual-weapon', 'spiritual weapon']],
+        ['Bless', ['bless', 'BLESS']]
+    ];
+
+    for (const [canonical, variants] of synonyms) {
+        it(`resolves "${canonical}" via every variant: ${variants.join(', ')}`, () => {
+            const expected = getSpell(canonical);
+            expect(expected, `canonical lookup of "${canonical}" failed`).toBeDefined();
+            for (const v of variants) {
+                expect(getSpell(v), `variant "${v}" did not resolve`).toBe(expected);
+                expect(spellExists(v), `spellExists("${v}") returned false`).toBe(true);
+            }
+        });
+    }
+
+    it('returns undefined for an actually-unknown spell', () => {
+        expect(getSpell('totally-made-up-spell-xyz')).toBeUndefined();
+        expect(spellExists('totally-made-up-spell-xyz')).toBe(false);
+    });
+
+    it('SPELL_COUNT counts unique spells, not key aliases', () => {
+        const uniqueSpells = new Set(SPELL_DATABASE.values()).size;
+        expect(SPELL_COUNT).toBe(uniqueSpells);
+    });
+});


### PR DESCRIPTION
## Summary
The spell catalog already contained `Fire Bolt`, `Magic Missile`, `Sacred Flame`, etc., but `getSpell("fire-bolt")` returned `undefined`. Root cause: the map was keyed by `name.toLowerCase()` (`"fire bolt"`) and `getSpell` did the same normalization, so kebab-case ids never matched. Surfaced as `Unknown spell: <name>` for almost every common spell.

## Fix
- `normalizeSpellKey` collapses whitespace/hyphens/underscores and lowercases.
- Each spell is registered under both its spaced name and its kebab-case id.
- `getSpell` / `spellExists` use the same normalizer, so `"Fire Bolt" / "fire-bolt" / "fire_bolt" / "FIREBOLT" / "firebolt"` all resolve to the same record.

## Test plan
- [x] New regression suite (`tests/engine/magic/spell-database.test.ts`) covers the eight spells the live test couldn't find.
- [x] spellcasting.test.ts: 71 passed, 3 skipped — no regressions.
- [x] Full suite: 1899 passed, 6 skipped, 0 failed.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spell lookups accept varied key formats (spacing, hyphens, underscores, casing) and resolve to the same spell.
  * Additional spells added to the database.

* **Bug Fixes**
  * Spell listings and class/level queries return deduplicated results so each spell appears once.
  * Spell count now reflects unique spells only, preventing alias-inflated totals.

* **Tests**
  * Added tests for key normalization, existence checks, iteration deduplication, and accurate spell count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->