### PR TITLE
fix(combat): participant `ac` field propagates through to attack resolver

### DIFF
--- a/src/engine/combat/engine.ts
+++ b/src/engine/combat/engine.ts
@@ -27,6 +27,11 @@ export interface CombatParticipant {
     isEnemy?: boolean;    // Whether this is an enemy (for turn automation)
     hp: number;
     maxHp: number;
+    /**
+     * Armor Class. Used by attack resolution. If omitted, the engine falls
+     * back to a derived value (10 + initiativeBonus/2) for legacy compatibility.
+     */
+    ac?: number;
     conditions: Condition[];
     position?: { x: number; y: number; z?: number };  // CRIT-003: Spatial position
     // Phase 4: Movement economy

--- a/src/engine/combat/engine.ts
+++ b/src/engine/combat/engine.ts
@@ -27,11 +27,6 @@ export interface CombatParticipant {
     isEnemy?: boolean;    // Whether this is an enemy (for turn automation)
     hp: number;
     maxHp: number;
-    /**
-     * Armor Class. Used by attack resolution. If omitted, the engine falls
-     * back to a derived value (10 + initiativeBonus/2) for legacy compatibility.
-     */
-    ac?: number;
     conditions: Condition[];
     position?: { x: number; y: number; z?: number };  // CRIT-003: Spatial position
     // Phase 4: Movement economy
@@ -74,7 +69,11 @@ export interface CombatParticipant {
     isStabilized?: boolean;       // Unconscious but won't die
     isDead?: boolean;             // Permanently defeated
     // COMBAT STATS (Auto-resolution)
-    ac?: number;               // Armor Class
+    /**
+     * Armor Class. Used by the attack resolver. If omitted, the engine falls
+     * back to a derived value (10 + initiativeBonus/2) for legacy compatibility.
+     */
+    ac?: number;
     attackDamage?: string;     // Default attack damage (e.g., "1d6+2")
     attackBonus?: number;      // Default attack bonus used if none provided
 }

--- a/src/schema/encounter.ts
+++ b/src/schema/encounter.ts
@@ -110,7 +110,12 @@ export const TokenSchema = z.object({
     attackBonus: z.number().optional().describe('Default attack bonus'),
     // Lair-action ownership — must be persisted so loadState can rebuild the
     // LAIR slot in turnOrder (see encounter.repo.ts loadState lookup).
-    hasLairActions: z.boolean().optional().describe('Whether this token owns lair actions')
+    hasLairActions: z.boolean().optional().describe('Whether this token owns lair actions'),
+    // Damage modifiers (HIGH-002) — must persist so post-load attack resolution
+    // continues to honor immunities/resistances/vulnerabilities.
+    resistances: z.array(z.string()).optional().describe('Damage types dealt at half damage'),
+    vulnerabilities: z.array(z.string()).optional().describe('Damage types dealt at double damage'),
+    immunities: z.array(z.string()).optional().describe('Damage types ignored entirely')
 });
 
 export type Token = z.infer<typeof TokenSchema>;

--- a/src/server/consolidated/combat-manage.ts
+++ b/src/server/consolidated/combat-manage.ts
@@ -40,6 +40,8 @@ const ParticipantSchema = z.object({
     initiativeBonus: z.number().int(),
     hp: z.number().int().nonnegative(), // Allow 0 HP for dying characters
     maxHp: z.number().int().positive(),
+    ac: z.number().int().min(0).optional()
+        .describe('Armor Class. If omitted, falls back to attacker-side derivation.'),
     isEnemy: z.boolean().optional(),
     /**
      * Convenience alias for `isEnemy`. Values "enemy" / "hostile" map to

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -1130,7 +1130,10 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
     const db = getDb(process.env.NODE_ENV === 'test' ? ':memory:' : 'rpg.db');
     const repo = new EncounterRepository(db);
 
-    // Create the encounter record first (with initiative and isEnemy)
+    // Create the encounter record first (with initiative and isEnemy).
+    // PR #57 follow-up: persist ac/attackDamage/attackBonus too — those drive
+    // attack resolution, and omitting them on initial create made loadState()
+    // (before any saveState) drop back to the default-AC-10 fallback.
     repo.create({
         id: encounterId,
         tokens: state.participants.map(p => ({
@@ -1144,6 +1147,10 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
             maxHp: p.maxHp,
             conditions: p.conditions,
             abilityScores: p.abilityScores,
+            // Combat stats used by the attack resolver
+            ac: p.ac,
+            attackDamage: p.attackDamage,
+            attackBonus: p.attackBonus,
             // Spatial visualization data
             position: p.position,
             movementSpeed: p.movementSpeed ?? 30,

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -1151,6 +1151,10 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
             ac: p.ac,
             attackDamage: p.attackDamage,
             attackBonus: p.attackBonus,
+            // Damage modifiers — drop them and post-load attacks lose half/2x/immune behavior
+            resistances: p.resistances,
+            vulnerabilities: p.vulnerabilities,
+            immunities: p.immunities,
             // Spatial visualization data
             position: p.position,
             movementSpeed: p.movementSpeed ?? 30,

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -579,6 +579,8 @@ Example (use real UUID from context for player character!):
                 isEnemy: z.boolean().optional().describe('Whether this is an enemy (auto-detected if not set)'),
                 hasLairActions: z.boolean().optional()
                     .describe('Adds a LAIR slot at initiative 20 to the turn order'),
+                ac: z.number().int().min(0).optional()
+                    .describe('Armor Class (used by attack resolution; defaults to attacker-side derivation if omitted)'),
                 conditions: z.array(z.string()).default([]),
                 position: z.object({ x: z.number(), y: z.number(), z: z.number().optional() }).optional()
                     .describe('CRIT-003: Spatial position for movement (x, y coordinates)'),
@@ -1102,7 +1104,10 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
             resistances: p.resistances,
             vulnerabilities: p.vulnerabilities,
             immunities: p.immunities,
-            ...extraStats
+            ...extraStats,
+            // Caller-supplied AC wins over the preset's default so explicit
+            // overrides (e.g., a goblin in chain mail) take effect.
+            ...(p.ac !== undefined ? { ac: p.ac } : {})
         } as CombatParticipant;
         
         return participant;

--- a/tests/server/consolidated/combat-manage.test.ts
+++ b/tests/server/consolidated/combat-manage.test.ts
@@ -167,6 +167,38 @@ describe('combat_manage consolidated tool', () => {
             expect(data.success).toBe(true);
         });
 
+        // PR #57 follow-up: damage modifiers must also survive the initial
+        // create -> loadState cycle. Dropping resistances/immunities/etc.
+        // changes damage resolution after a cold load.
+        it('persists resistances/immunities/vulnerabilities into the initial encounter row', async () => {
+            const { EncounterRepository } = await import('../../../src/storage/repos/encounter.repo.js');
+            const createResult = await handleCombatManage({
+                action: 'create',
+                seed: 'damage-mods-cold-load',
+                participants: [
+                    {
+                        id: 'fire-elem',
+                        name: 'Fire Elemental',
+                        initiativeBonus: 0,
+                        hp: 30,
+                        maxHp: 30,
+                        isEnemy: true,
+                        resistances: ['bludgeoning', 'piercing', 'slashing'],
+                        immunities: ['fire'],
+                        vulnerabilities: ['cold']
+                    }
+                ]
+            }, ctx);
+            const encounterId = parseResult(createResult).encounterId;
+
+            const repo = new EncounterRepository(getDb(':memory:'));
+            const loaded = repo.loadState(encounterId);
+            const elem = loaded.participants.find((p: { id: string }) => p.id === 'fire-elem');
+            expect(elem?.resistances).toEqual(['bludgeoning', 'piercing', 'slashing']);
+            expect(elem?.immunities).toEqual(['fire']);
+            expect(elem?.vulnerabilities).toEqual(['cold']);
+        });
+
         // PR #57 follow-up: ensure ac survives an initial create -> loadState
         // round-trip even before any saveState() is called.
         it('persists ac into the initial encounter row (no loss on cold load)', async () => {

--- a/tests/server/consolidated/combat-manage.test.ts
+++ b/tests/server/consolidated/combat-manage.test.ts
@@ -167,6 +167,26 @@ describe('combat_manage consolidated tool', () => {
             expect(data.success).toBe(true);
         });
 
+        // PR #57 follow-up: ensure ac survives an initial create -> loadState
+        // round-trip even before any saveState() is called.
+        it('persists ac into the initial encounter row (no loss on cold load)', async () => {
+            const { EncounterRepository } = await import('../../../src/storage/repos/encounter.repo.js');
+            const createResult = await handleCombatManage({
+                action: 'create',
+                seed: 'ac-persistence-cold-load',
+                participants: [
+                    { id: 'tanky', name: 'Tank', initiativeBonus: 0, hp: 30, maxHp: 30, ac: 18, isEnemy: false }
+                ]
+            }, ctx);
+            const encounterId = parseResult(createResult).encounterId;
+
+            const repo = new EncounterRepository(getDb(':memory:'));
+            const loaded = repo.loadState(encounterId);
+            expect(loaded).not.toBeNull();
+            const tank = loaded.participants.find((p: { id: string; ac?: number }) => p.id === 'tanky');
+            expect(tank?.ac).toBe(18);
+        });
+
         // Regression for issue #47: participant `ac` was being silently dropped
         // by the consolidated schema and never reached the attack resolver. All
         // attacks resolved vs AC 10 regardless of the supplied value.

--- a/tests/server/consolidated/combat-manage.test.ts
+++ b/tests/server/consolidated/combat-manage.test.ts
@@ -166,6 +166,28 @@ describe('combat_manage consolidated tool', () => {
             const data = parseResult(result);
             expect(data.success).toBe(true);
         });
+
+        // Regression for issue #47: participant `ac` was being silently dropped
+        // by the consolidated schema and never reached the attack resolver. All
+        // attacks resolved vs AC 10 regardless of the supplied value.
+        it('honors participant `ac` in encounter state', async () => {
+            const result = await handleCombatManage({
+                action: 'create',
+                seed: 'ac-persistence-test',
+                participants: [
+                    { id: 'tanky-pc', name: 'Tank', initiativeBonus: 0, hp: 38, maxHp: 38, ac: 18, isEnemy: false, position: { x: 0, y: 0 } },
+                    { id: 'squishy-enemy', name: 'Bandit', initiativeBonus: 0, hp: 10, maxHp: 10, ac: 11, isEnemy: true, position: { x: 1, y: 0 } }
+                ]
+            }, ctx);
+            const data = parseResult(result);
+            expect(data.success).toBe(true);
+
+            const byId = Object.fromEntries(
+                (data.participants as Array<{ id: string; ac?: number }>).map((p) => [p.id, p.ac])
+            );
+            expect(byId['tanky-pc']).toBe(18);
+            expect(byId['squishy-enemy']).toBe(11);
+        });
     });
 
     describe('get action', () => {


### PR DESCRIPTION
## Summary
Caller-supplied `ac` on participants was silently dropped by the consolidated combat_manage schema and never reached `CombatParticipant`. Attacks resolved against AC 10 regardless of the value passed.

## Fix
- `ac?: number` added to `CombatParticipant` interface.
- Accepted on both `ParticipantSchema` (consolidated) and the inner `create_encounter` input schema.
- Participant builder reads `p.ac`, with caller values overriding creature-preset AC when both are present.
- No engine change: `target.ac` was already the preferred source in the attack handler — this PR just ensures the value is actually set.

## Test plan
- [x] Regression test asserts `ac: 18` and `ac: 11` round-trip through to encounter state.
- [x] combat-manage suite: 22/22 pass
- [x] combat-action suite: 25/25 pass
- [x] Full suite: 1890 passed, 6 skipped, 0 failed

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Participants may include an optional Armor Class (AC); supplied AC overrides derived AC and is persisted. Participant damage modifiers (resistances, vulnerabilities, immunities), attack bonus, and attack damage are persisted on creation.
* **Bug Fixes**
  * Ensures supplied AC and combat stats are retained after encounter creation and load.
* **Tests**
  * Added regression tests verifying persistence and returned participant AC and damage modifiers.
* **Documentation**
  * Clarified AC semantics and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->