### PR TITLE
fix(combat): surface off-turn advisory when actorId isn't on turn

### DIFF
--- a/src/schema/encounter.ts
+++ b/src/schema/encounter.ts
@@ -107,7 +107,10 @@ export const TokenSchema = z.object({
     // Combat Stats for Auto-Resolution
     ac: z.number().optional().describe('Armor Class for auto-resolution'),
     attackDamage: z.string().optional().describe('Default attack damage (e.g., "1d6+2")'),
-    attackBonus: z.number().optional().describe('Default attack bonus')
+    attackBonus: z.number().optional().describe('Default attack bonus'),
+    // Lair-action ownership — must be persisted so loadState can rebuild the
+    // LAIR slot in turnOrder (see encounter.repo.ts loadState lookup).
+    hasLairActions: z.boolean().optional().describe('Whether this token owns lair actions')
 });
 
 export type Token = z.infer<typeof TokenSchema>;

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -577,6 +577,8 @@ Example (use real UUID from context for player character!):
                 hp: z.number().int().nonnegative(), // Allow 0 HP for dying characters
                 maxHp: z.number().int().positive(),
                 isEnemy: z.boolean().optional().describe('Whether this is an enemy (auto-detected if not set)'),
+                hasLairActions: z.boolean().optional()
+                    .describe('Adds a LAIR slot at initiative 20 to the turn order'),
                 conditions: z.array(z.string()).default([]),
                 position: z.object({ x: z.number(), y: z.number(), z: z.number().optional() }).optional()
                     .describe('CRIT-003: Spatial position for movement (x, y coordinates)'),
@@ -1094,6 +1096,7 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
             initiative: 0, // Will be rolled
             initiativeBonus: p.initiativeBonus ?? 0,
             isEnemy: p.isEnemy ?? false,
+            hasLairActions: p.hasLairActions ?? false,
             conditions: p.conditions || [],
             position: p.position,
             resistances: p.resistances,
@@ -1253,14 +1256,18 @@ export async function handleExecuteCombatAction(args: unknown, ctx: SessionConte
             const activeId = liveState.turnOrder[liveState.currentTurnIndex];
             if (
                 activeId &&
-                activeId !== 'LAIR' &&
                 parsed.actorId !== activeId &&
                 // Ignore if the supplied actorId isn't a real participant —
                 // the action handler will produce a clearer error downstream.
                 liveState.participants.some((p) => p.id === parsed.actorId)
             ) {
-                const actor = liveState.participants.find((p) => p.id === activeId);
-                turnWarning = `off_turn_action: ${parsed.actorId} acting during ${actor?.name ?? activeId}'s turn`;
+                // LAIR turns are still off-turn for participant actions: only
+                // the lair_action tool may resolve during initiative-20 LAIR.
+                const isLair = activeId === 'LAIR';
+                const activeLabel = isLair
+                    ? 'LAIR action'
+                    : (liveState.participants.find((p) => p.id === activeId)?.name ?? activeId);
+                turnWarning = `off_turn_action: ${parsed.actorId} acting during ${activeLabel}'s turn`;
             }
         }
     }

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -1239,6 +1239,32 @@ export async function handleExecuteCombatAction(args: unknown, ctx: SessionConte
         getCombatManager().create(`${ctx.sessionId}:${parsed.encounterId}`, engine);
     }
 
+    // Turn-identity advisory (issue #49). Every action routed through this
+    // handler (attack / cast_spell / move / dash / dodge / help / heal /
+    // disengage / ready) is an on-turn action. If actorId doesn't match the
+    // active participant, surface a warning so the caller can see the
+    // misuse — we don't throw because reactions aren't modeled yet and
+    // some legitimate flows could be disrupted. A stricter mode can be
+    // layered on top later.
+    let turnWarning: string | undefined;
+    {
+        const liveState = engine.getState();
+        if (liveState) {
+            const activeId = liveState.turnOrder[liveState.currentTurnIndex];
+            if (
+                activeId &&
+                activeId !== 'LAIR' &&
+                parsed.actorId !== activeId &&
+                // Ignore if the supplied actorId isn't a real participant —
+                // the action handler will produce a clearer error downstream.
+                liveState.participants.some((p) => p.id === parsed.actorId)
+            ) {
+                const actor = liveState.participants.find((p) => p.id === activeId);
+                turnWarning = `off_turn_action: ${parsed.actorId} acting during ${actor?.name ?? activeId}'s turn`;
+            }
+        }
+    }
+
     let result: CombatActionResult | undefined;
     let output = '';
 
@@ -2023,6 +2049,10 @@ export async function handleExecuteCombatAction(args: unknown, ctx: SessionConte
         // Append current state JSON for frontend
         const stateJson = buildStateJson(state, parsed.encounterId);
         output += `\n\n<!-- STATE_JSON\n${JSON.stringify(stateJson)}\nSTATE_JSON -->`;
+    }
+
+    if (turnWarning) {
+        output += `\n\n⚠️  ${turnWarning}\n`;
     }
 
     return {

--- a/src/server/handlers/combat-handlers.ts
+++ b/src/server/handlers/combat-handlers.ts
@@ -1134,6 +1134,7 @@ export async function handleCreateEncounter(args: unknown, ctx: SessionContext) 
             initiativeBonus: p.initiativeBonus,
             initiative: p.initiative,    // Store rolled initiative
             isEnemy: p.isEnemy,          // Store enemy flag
+            hasLairActions: p.hasLairActions,  // PR #59 follow-up: persist lair flag so loadState can rebuild the LAIR slot
             hp: p.hp,
             maxHp: p.maxHp,
             conditions: p.conditions,

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -98,6 +98,39 @@ describe('combat_action consolidated tool', () => {
         });
     });
 
+    // Regression for issue #49: off-turn actions used to succeed silently,
+    // letting a caller stack multiple attacks from different actors in one
+    // round. Now the response surfaces an off_turn_action warning.
+    describe('off-turn advisory', () => {
+        it('warns when actorId does not match the current-turn participant', async () => {
+            // Test setup gave hero-1 initiativeBonus 10 vs goblin-1's 1, so
+            // hero-1 is on turn. Fire an attack as the goblin instead.
+            const result = await handleCombatAction({
+                action: 'attack',
+                encounterId: testEncounterId,
+                actorId: 'goblin-1',
+                targetId: 'hero-1',
+                attackBonus: 3,
+                damage: 4
+            }, ctx);
+
+            expect(result.content[0].text).toMatch(/off_turn_action/);
+        });
+
+        it('does not warn when actorId is the current-turn participant', async () => {
+            const result = await handleCombatAction({
+                action: 'attack',
+                encounterId: testEncounterId,
+                actorId: 'hero-1',
+                targetId: 'goblin-1',
+                attackBonus: 5,
+                damage: 8
+            }, ctx);
+
+            expect(result.content[0].text).not.toMatch(/off_turn_action/);
+        });
+    });
+
     describe('attack action', () => {
         it('should execute an attack', async () => {
             const result = await handleCombatAction({

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -130,6 +130,31 @@ describe('combat_action consolidated tool', () => {
             expect(result.content[0].text).not.toMatch(/off_turn_action/);
         });
 
+        // Reviewer follow-up on PR #59: hasLairActions wasn't being persisted,
+        // so loadState() couldn't rebuild the LAIR slot in turnOrder after a
+        // restart. The lair turn would silently disappear.
+        it('persists hasLairActions so LAIR survives a loadState round-trip', async () => {
+            const { handleCreateEncounter } = await import('../../../src/server/handlers/combat-handlers.js');
+            const { EncounterRepository } = await import('../../../src/storage/repos/encounter.repo.js');
+            const lairCtx = { sessionId: `lair-persist-${randomUUID()}` };
+
+            const create = await handleCreateEncounter({
+                seed: 'lair-persist-test',
+                participants: [
+                    { id: 'pc', name: 'Hero', initiativeBonus: 0, hp: 30, maxHp: 30, isEnemy: false, position: { x: 0, y: 0 } },
+                    { id: 'dragon', name: 'Dragon', initiativeBonus: 0, hp: 100, maxHp: 100, isEnemy: true, hasLairActions: true, position: { x: 5, y: 5 } }
+                ]
+            }, lairCtx);
+            const eid = (create.content[0].text.match(/encounter-[\w-]+/) || [])[0]!;
+
+            const repo = new EncounterRepository(getDb(':memory:'));
+            const loaded = repo.loadState(eid);
+            expect(loaded).not.toBeNull();
+            expect(loaded.turnOrder).toContain('LAIR');
+            const dragon = loaded.participants.find((p: { id: string }) => p.id === 'dragon');
+            expect(dragon?.hasLairActions).toBe(true);
+        });
+
         // Reviewer follow-up on PR #59: previously the warning was suppressed
         // when the active turn slot was 'LAIR', so a participant could still
         // act mid-LAIR-turn without any signal. The warning should fire.

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -129,6 +129,46 @@ describe('combat_action consolidated tool', () => {
 
             expect(result.content[0].text).not.toMatch(/off_turn_action/);
         });
+
+        // Reviewer follow-up on PR #59: previously the warning was suppressed
+        // when the active turn slot was 'LAIR', so a participant could still
+        // act mid-LAIR-turn without any signal. The warning should fire.
+        it('warns when a participant acts during a LAIR turn', async () => {
+            const { handleCreateEncounter, handleExecuteCombatAction } =
+                await import('../../../src/server/handlers/combat-handlers.js');
+            const lairCtx = { sessionId: `lair-test-${randomUUID()}` };
+
+            // Construct an encounter with a LAIR-bearing creature so that the
+            // turn order includes a 'LAIR' slot at initiative 20.
+            const create = await handleCreateEncounter({
+                seed: 'lair-warning-test',
+                participants: [
+                    { id: 'pc', name: 'Hero', initiativeBonus: 0, hp: 30, maxHp: 30, isEnemy: false, position: { x: 0, y: 0 } },
+                    { id: 'dragon', name: 'Dragon', initiativeBonus: 0, hp: 100, maxHp: 100, isEnemy: true, hasLairActions: true, position: { x: 5, y: 5 } }
+                ]
+            }, lairCtx);
+            const lairEncounterId = (create.content[0].text.match(/encounter-[\w-]+/) || [])[0]!;
+
+            // Force the active slot to LAIR by advancing turns until we hit it.
+            const { getCombatManager } = await import('../../../src/server/state/combat-manager.js');
+            const engine = getCombatManager().get(`${lairCtx.sessionId}:${lairEncounterId}`)!;
+            const state = engine.getState()!;
+            const lairIndex = state.turnOrder.indexOf('LAIR');
+            expect(lairIndex).toBeGreaterThanOrEqual(0);
+            state.currentTurnIndex = lairIndex;
+
+            // Now PC tries to act — should warn even though the active slot is LAIR.
+            const acted = await handleExecuteCombatAction({
+                encounterId: lairEncounterId,
+                action: 'attack',
+                actorId: 'pc',
+                targetId: 'dragon',
+                attackBonus: 3,
+                damage: 5
+            }, lairCtx);
+            expect(acted.content[0].text).toMatch(/off_turn_action/);
+            expect(acted.content[0].text).toMatch(/LAIR action/);
+        });
     });
 
     describe('attack action', () => {


### PR DESCRIPTION
## Summary
`combat_action` resolved actions regardless of whose turn it was — letting a caller fire an attack as an off-turn participant, then fire again when their real turn comes up. Live session observed Marisol attacking twice in a round.

## Approach
A hard reject broke 39 existing tests that rely on initiative-order guessing (they'd need individual fixes). This PR chooses the smaller-blast-radius path: emit an `off_turn_action: <actorId> acting during <name>'s turn` advisory in the response. Production callers see the misuse; existing flows remain intact.

## Scope
- Warning fires only when `actorId` is a real participant that is not the current-turn participant.
- Unknown actors still hit the downstream error (more specific).

## Future work
Promote to a hard reject once the test fixtures that depend on initiative-order guessing are fixed. Tracked implicitly — if the team wants, I can open a follow-up.

## Test plan
- [x] New test: off-turn actor → response contains `off_turn_action` text.
- [x] New test: on-turn actor → no warning.
- [x] combat-action suite: 27/27
- [x] Full suite: 1891 passed, 6 skipped, 0 failed

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combat actions now display an advisory when executed out-of-turn; lair actions are specially labeled in that advisory.
* **Tests**
  * Added test coverage validating off-turn advisories, absence when on-turn, and lair-slot advisory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->