### PR TITLE
fix(combat): dash actually extends the enforced movement budget

### DIFF
--- a/src/engine/combat/engine.ts
+++ b/src/engine/combat/engine.ts
@@ -996,6 +996,27 @@ export class CombatEngine {
     }
 
     /**
+     * Apply the Dash action for a participant. Adds a fresh movement
+     * allotment on top of whatever they already have left, and flags
+     * hasDashed so the budget-check in move actions sees the doubled
+     * window. Consumes the main action.
+     */
+    applyDash(participantId: string): { ok: true; movementRemaining: number } | { ok: false; error: string } {
+        if (!this.state) return { ok: false, error: 'No active combat' };
+        const participant = this.state.participants.find((p) => p.id === participantId);
+        if (!participant) return { ok: false, error: `Participant ${participantId} not found` };
+        if (participant.hasDashed) return { ok: false, error: 'Already dashed this turn' };
+
+        const baseSpeed = participant.movementSpeed ?? 30;
+        const currentRemaining = participant.movementRemaining ?? baseSpeed;
+        participant.movementRemaining = currentRemaining + baseSpeed;
+        participant.hasDashed = true;
+        participant.actionUsed = true;
+
+        return { ok: true, movementRemaining: participant.movementRemaining };
+    }
+
+    /**
      * Process start-of-turn condition effects
      */
     private processStartOfTurnConditions(participant: CombatParticipant): void {

--- a/src/engine/combat/engine.ts
+++ b/src/engine/combat/engine.ts
@@ -1007,6 +1007,14 @@ export class CombatEngine {
         if (!participant) return { ok: false, error: `Participant ${participantId} not found` };
         if (participant.hasDashed) return { ok: false, error: 'Already dashed this turn' };
 
+        // Dash IS the action. Reject if the participant already burned their
+        // main action this turn (5e action economy). Without this guard, a
+        // caller could attack and then dash for a free 60ft of movement.
+        const econ = this.validateActionEconomy(participantId, 'action');
+        if (!econ.valid) {
+            return { ok: false, error: econ.error || 'Action already used this turn' };
+        }
+
         const baseSpeed = participant.movementSpeed ?? 30;
         const currentRemaining = participant.movementRemaining ?? baseSpeed;
         participant.movementRemaining = currentRemaining + baseSpeed;

--- a/src/server/consolidated/combat-action.ts
+++ b/src/server/consolidated/combat-action.ts
@@ -200,14 +200,31 @@ const definitions: Record<CombatAction, ActionDefinition> = {
             // pattern in handleExecuteCombatAction). Without this, dash
             // returned "not found" after a process restart even when the
             // encounter still existed and other actions worked.
+            //
+            // Race-safe restore (PR #60 reviewer ask): two concurrent
+            // requests can both find the engine missing and both load from
+            // DB. CombatManager.create throws if the key already exists, so
+            // wrap the create in a try/get fallback — the loser of the race
+            // adopts the winner's engine.
             if (!engine) {
                 const db = getDb(process.env.NODE_ENV === 'test' ? ':memory:' : 'rpg.db');
                 const repo = new EncounterRepository(db);
                 const persisted = repo.loadState(params.encounterId);
                 if (persisted) {
-                    engine = new CombatEngine(params.encounterId);
-                    engine.loadState(persisted);
-                    getCombatManager().create(sessionKey, engine);
+                    // Re-check in case another concurrent request restored it
+                    // between our initial get() and now.
+                    engine = getCombatManager().get(sessionKey);
+                    if (!engine) {
+                        const candidate = new CombatEngine(params.encounterId);
+                        candidate.loadState(persisted);
+                        try {
+                            getCombatManager().create(sessionKey, candidate);
+                            engine = candidate;
+                        } catch {
+                            // Lost the race — adopt the engine the winner created.
+                            engine = getCombatManager().get(sessionKey);
+                        }
+                    }
                 }
             }
 

--- a/src/server/consolidated/combat-action.ts
+++ b/src/server/consolidated/combat-action.ts
@@ -9,6 +9,7 @@ import { createActionRouter, ActionDefinition, McpResponse } from '../../utils/a
 import { SessionContext } from '../types.js';
 import { RichFormatter } from '../utils/formatter.js';
 import { handleExecuteCombatAction } from '../handlers/combat-handlers.js';
+import { getCombatManager } from '../state/combat-manager.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -188,13 +189,30 @@ const definitions: Record<CombatAction, ActionDefinition> = {
         schema: DashSchema,
         handler: async (params: z.infer<typeof DashSchema>) => {
             if (!currentContext) throw new Error('No session context');
-            // Dash doubles movement speed for the turn
+            const engine = getCombatManager().get(`${currentContext.sessionId}:${params.encounterId}`);
+            if (!engine) {
+                return {
+                    error: true,
+                    actionType: 'dash',
+                    message: `Encounter ${params.encounterId} not found.`
+                };
+            }
+            const result = engine.applyDash(params.actorId);
+            if (!result.ok) {
+                return {
+                    error: true,
+                    actionType: 'dash',
+                    actorId: params.actorId,
+                    message: result.error
+                };
+            }
             return {
                 success: true,
                 actionType: 'dash',
                 actorId: params.actorId,
-                effect: 'Movement speed doubled for this turn',
-                message: `${params.actorId} takes the Dash action, doubling movement speed.`
+                movementRemaining: result.movementRemaining,
+                effect: `Movement speed doubled for this turn (budget now ${result.movementRemaining}ft)`,
+                message: `${params.actorId} takes the Dash action. Movement doubled; ${result.movementRemaining}ft remaining.`
             };
         },
         aliases: ['sprint', 'run', 'hustle']

--- a/src/server/consolidated/combat-action.ts
+++ b/src/server/consolidated/combat-action.ts
@@ -10,6 +10,9 @@ import { SessionContext } from '../types.js';
 import { RichFormatter } from '../utils/formatter.js';
 import { handleExecuteCombatAction } from '../handlers/combat-handlers.js';
 import { getCombatManager } from '../state/combat-manager.js';
+import { getDb } from '../../storage/index.js';
+import { EncounterRepository } from '../../storage/repos/encounter.repo.js';
+import { CombatEngine } from '../../engine/combat/engine.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -189,7 +192,25 @@ const definitions: Record<CombatAction, ActionDefinition> = {
         schema: DashSchema,
         handler: async (params: z.infer<typeof DashSchema>) => {
             if (!currentContext) throw new Error('No session context');
-            const engine = getCombatManager().get(`${currentContext.sessionId}:${params.encounterId}`);
+
+            const sessionKey = `${currentContext.sessionId}:${params.encounterId}`;
+            let engine = getCombatManager().get(sessionKey);
+
+            // Auto-load from DB if the engine isn't in memory (matches the
+            // pattern in handleExecuteCombatAction). Without this, dash
+            // returned "not found" after a process restart even when the
+            // encounter still existed and other actions worked.
+            if (!engine) {
+                const db = getDb(process.env.NODE_ENV === 'test' ? ':memory:' : 'rpg.db');
+                const repo = new EncounterRepository(db);
+                const persisted = repo.loadState(params.encounterId);
+                if (persisted) {
+                    engine = new CombatEngine(params.encounterId);
+                    engine.loadState(persisted);
+                    getCombatManager().create(sessionKey, engine);
+                }
+            }
+
             if (!engine) {
                 return {
                     error: true,

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -283,6 +283,44 @@ describe('combat_action consolidated tool', () => {
             expect(data.actionType).toBe('dash');
         });
 
+        // Reviewer follow-ups on PR #60:
+        // - dash must consume the action economy slot (else attack-then-dash).
+        // - dash must auto-load the engine from DB (matches other actions).
+        it('dash refuses when the actor already used their main action this turn', async () => {
+            // hero-1 attacks (consumes action) then tries to dash.
+            await handleCombatAction({
+                action: 'attack',
+                encounterId: testEncounterId,
+                actorId: 'hero-1',
+                targetId: 'goblin-1',
+                attackBonus: 5,
+                damage: 4
+            }, ctx);
+
+            const dashResult = await handleCombatAction({
+                action: 'dash',
+                encounterId: testEncounterId,
+                actorId: 'hero-1'
+            }, ctx);
+            const dashData = parseResult(dashResult);
+            expect(dashData.error).toBe(true);
+            expect(dashData.message).toMatch(/already used|action/i);
+        });
+
+        it('dash auto-loads the encounter from DB when engine is evicted', async () => {
+            const { getCombatManager } = await import('../../../src/server/state/combat-manager.js');
+            getCombatManager().clear();
+
+            const dashResult = await handleCombatAction({
+                action: 'dash',
+                encounterId: testEncounterId,
+                actorId: 'hero-1'
+            }, ctx);
+            const dashData = parseResult(dashResult);
+            expect(dashData.success).toBe(true);
+            expect(dashData.movementRemaining).toBe(60);
+        });
+
         // Regression for issue #50: dash was a stub that returned a success
         // message without actually extending movementRemaining, so the next
         // move call still enforced the base 30ft budget.

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -307,6 +307,38 @@ describe('combat_action consolidated tool', () => {
             expect(dashData.message).toMatch(/already used|action/i);
         });
 
+        // Reviewer follow-up on PR #60 (Minor): two concurrent dash calls
+        // hitting the auto-load path could both try to register the same
+        // engine key, throwing "Encounter X already exists" on the loser.
+        it('dash survives two concurrent auto-load requests without throwing', async () => {
+            const { getCombatManager } = await import('../../../src/server/state/combat-manager.js');
+            getCombatManager().clear();
+
+            const [a, b] = await Promise.all([
+                handleCombatAction({
+                    action: 'dash',
+                    encounterId: testEncounterId,
+                    actorId: 'hero-1'
+                }, ctx),
+                handleCombatAction({
+                    action: 'dash',
+                    encounterId: testEncounterId,
+                    actorId: 'hero-1'
+                }, ctx)
+            ]);
+
+            const da = parseResult(a);
+            const db = parseResult(b);
+            // One must succeed (the first) and the other must reject due to
+            // hasDashed/economy — but neither may throw "already exists".
+            expect([da, db].some((d) => d.success === true)).toBe(true);
+            for (const d of [da, db]) {
+                if (d.error) {
+                    expect(String(d.message ?? '')).not.toMatch(/already exists/i);
+                }
+            }
+        });
+
         it('dash auto-loads the encounter from DB when engine is evicted', async () => {
             const { getCombatManager } = await import('../../../src/server/state/combat-manager.js');
             getCombatManager().clear();

--- a/tests/server/consolidated/combat-action.test.ts
+++ b/tests/server/consolidated/combat-action.test.ts
@@ -282,6 +282,31 @@ describe('combat_action consolidated tool', () => {
             // Alias resolves to dash
             expect(data.actionType).toBe('dash');
         });
+
+        // Regression for issue #50: dash was a stub that returned a success
+        // message without actually extending movementRemaining, so the next
+        // move call still enforced the base 30ft budget.
+        it('dash actually doubles the enforced move budget', async () => {
+            const dashResult = await handleCombatAction({
+                action: 'dash',
+                encounterId: testEncounterId,
+                actorId: 'hero-1'
+            }, ctx);
+            const dashData = parseResult(dashResult);
+            expect(dashData.success).toBe(true);
+            expect(dashData.movementRemaining).toBe(60);
+
+            // Move 9 tiles diagonally (~45ft at 5ft/sq). Without dash this
+            // would exceed the 30ft budget; with dash (60ft) it fits.
+            const moveResult = await handleCombatAction({
+                action: 'move',
+                encounterId: testEncounterId,
+                actorId: 'hero-1',
+                targetPosition: { x: 14, y: 14 }
+            }, ctx);
+            const moveData = parseResult(moveResult);
+            expect(moveData.success).toBe(true);
+        });
     });
 
     describe('dodge action', () => {


### PR DESCRIPTION
## Summary
The consolidated `dash` handler was a no-op stub — it returned "Movement speed doubled" but never told the engine. The next `move` still enforced the base 30ft budget and rejected with `Insufficient movement`. Observed live when a dashing zealot couldn't cross the aisle.

## Fix
- `CombatEngine.applyDash()` — adds a fresh `baseSpeed` allotment on top of any existing `movementRemaining`, flags `hasDashed`, and consumes the main action (5e dash rules).
- `dash` handler in `combat-action.ts` calls `applyDash` and echoes the new `movementRemaining` so callers can see their budget.

## Test plan
- [x] Existing dash test kept passing (effect string still contains "doubled").
- [x] New regression test: dash then diagonal move that would exceed 30ft succeeds with the 60ft budget.
- [x] combat-action suite: 26/26
- [x] Full suite: 1890 passed, 6 skipped, 0 failed

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dash now actually increases a participant’s available movement, enforces once-per-turn use, and rejects dash if the main action is already spent.
  * Handler recovers encounter state when in-memory engine is missing and returns structured errors when the encounter or dash cannot be applied.
* **Tests**
  * Added regression tests covering action-economy rejection, persist/reload behavior, and doubled movement verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->