### PR TITLE
fix(travel): crash on currentLocation column name mismatch

### DIFF
--- a/src/server/consolidated/travel-manage.ts
+++ b/src/server/consolidated/travel-manage.ts
@@ -167,7 +167,7 @@ async function handleTravel(input: TravelManageInput, _ctx: SessionContext): Pro
     }
 
     // Update party position
-    db.prepare('UPDATE parties SET currentLocation = ?, updated_at = ? WHERE id = ?')
+    db.prepare('UPDATE parties SET current_location = ?, updated_at = ? WHERE id = ?')
         .run(poi.name, new Date().toISOString(), input.partyId);
 
     // Enter location if requested

--- a/tests/server/consolidated/travel-manage.test.ts
+++ b/tests/server/consolidated/travel-manage.test.ts
@@ -71,12 +71,8 @@ describe('travel_manage consolidated tool', () => {
             )
         `);
 
-        // Add currentLocation column to parties if needed
-        try {
-            db.exec(`ALTER TABLE parties ADD COLUMN currentLocation TEXT`);
-        } catch {
-            // Column might already exist
-        }
+        // No workaround column — the migration defines current_location (snake_case)
+        // and the handler must use the correct column name
 
         // Create test characters
         const charRepo = new CharacterRepository(db);


### PR DESCRIPTION
## Summary
- Fixed `travel_manage` travel action crash caused by raw SQL using `currentLocation` (camelCase) instead of `current_location` (snake_case) — the actual column name in the `parties` table migration
- Removed test workaround that was masking the bug by adding a duplicate camelCase column via `ALTER TABLE`

## Root Cause
`src/server/consolidated/travel-manage.ts:170` used `currentLocation` in a raw `UPDATE` statement, but the `parties` table schema (migrations.ts:309) defines the column as `current_location`. The `PartyRepository` uses the correct snake_case name throughout, but the `handleTravel` function bypassed the repo and used raw SQL with the wrong casing.

## Test plan
- [x] Removed test workaround (ALTER TABLE adding camelCase column) so tests validate against real schema
- [x] All 26 travel_manage tests pass
- [x] Full suite: 1971 passed, 6 skipped, 0 failed

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency for travel management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/mnehmos.rpg.mcp/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->